### PR TITLE
minor fix to matplotlib bibliography entry

### DIFF
--- a/manuscript/paper.bib
+++ b/manuscript/paper.bib
@@ -252,7 +252,7 @@
 	pages = {90--95},
 	author = {John D. Hunter},
 	title = {Matplotlib: A 2D Graphics Environment},
-	journal = {Computing in Science {\&}amp$\mathsemicolon$ Engineering}
+	journal = {Computing in Science \& Engineering}
 }
 
 


### PR DESCRIPTION
semicolon placed in journal title causing JOSS publish steps to fail

this can happen sometimes with auto-generated references; I've updated the entry to remove this and (hopefully) fix the build issue.